### PR TITLE
support for Hidden posts

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -68,7 +68,7 @@
     {{- end -}}
     
     {{/* List only pages that are not a subsection */}}
-    {{ $paginator := .Paginate $pages }}
+    {{ $paginator := .Paginate (where ".Params.hidden" "!=" "true") }}
     <section class="article-list--compact">
         {{ range $paginator.Pages }}
             {{ partial "article-list/compact" . }}

--- a/layouts/partials/head/head.html
+++ b/layouts/partials/head/head.html
@@ -1,6 +1,8 @@
 <meta charset='utf-8'>
 <meta name='viewport' content='width=device-width, initial-scale=1'>
 
+<meta content="{{ if .Params.hidden }}noindex{{ else }}index{{ end }}, follow" name="robots">
+
 {{- $description := partialCached "data/description" . .RelPermalink -}}
 <meta name='description' content='{{ $description }}'>
 {{ with .Params.Keywords }}<meta name="keywords" content="{{ delimit . ", " }}">{{ end }}


### PR DESCRIPTION
category listの合計数がおかしいけど、できた
* meta tagでindexしないようにする
* リストに表示しないようにする

ができた。

### 制限

* 2記事しか表示されていないのに、3 pagesと表示される。
<img width="391" alt="スクリーンショット 2023-07-21 23 45 09" src="https://github.com/noctavation/hugo-theme-stack/assets/49445799/e382c569-55d4-4399-b9ce-44d56b3f447d">
