### PR TITLE
fix error on build

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -68,7 +68,7 @@
     {{- end -}}
     
     {{/* List only pages that are not a subsection */}}
-    {{ $paginator := .Paginate (where ".Params.hidden" "!=" "true") }}
+    {{ $paginator := .Paginate (where .Pages ".Params.hidden" "!=" "true") }}
     <section class="article-list--compact">
         {{ range $paginator.Pages }}
             {{ partial "article-list/compact" . }}


### PR DESCRIPTION
## fixing error
```
❯ hugo server
Start building sites … 
hugo v0.115.3+extended linux/amd64 BuildDate=unknown

ERROR render of "section" failed: "hugo-theme-stack/layouts/_default/list.html:71:32": execute of template failed: template: _default/list.html:71:32: executing "main" at <where ".Params.hidden" "!=" "true">: error calling where: can't iterate over .Params.hidden
ERROR render of "taxonomy" failed: "hugo-theme-stack/layouts/_default/list.html:71:32": execute of template failed: template: _default/list.html:71:32: executing "main" at <where ".Params.hidden" "!=" "true">: error calling where: can't iterate over .Params.hidden
ERROR render of "term" failed: "hugo-theme-stack/layouts/_default/list.html:71:32": execute of template failed: template: _default/list.html:71:32: executing "main" at <where ".Params.hidden" "!=" "true">: error calling where: can't iterate over .Params.hidden
Built in 189 ms
Error: error building site: render: failed to render pages: render of "section" failed: "hugo-theme-stack/layouts/_default/list.html:71:32": execute of template failed: template: _default/list.html:71:32: executing "main" at <where ".Params.hidden" "!=" "true">: error calling where: can't iterate over .Params.hidden
```
* file paths are simplified

after this change no error occurs on `hugo server`